### PR TITLE
add back in scripts

### DIFF
--- a/demo-ng/package.json
+++ b/demo-ng/package.json
@@ -29,6 +29,12 @@
   "bugs": {
     "url": "https://github.com/NativeScript/NativeScript/issues"
   },
+  "scripts": {
+		"clean": "npx rimraf hooks node_modules package-lock.json && npm i",
+		"start.ios": "ns run ios --no-hmr",
+		"start.android": "ns run android --no-hmr",
+		"prepare": "cd .. && husky install demo-ng/.husky"
+	},
   "dependencies": {
     "@angular/animations": "~11.2.7",
     "@angular/common": "~11.2.7",


### PR DESCRIPTION
I was just checking out this demo and noticed that the npm scripts referenced in the README weren't working. It seems they got lost here https://github.com/williamjuan027/nativescript-rootlayout-demo/pull/1/files#diff-77f49514b7e05ae7431e9f925732ec150ba4e5615003ff9c0f0de00a33b26a25 

Since they are still referenced in the README I assume this was an accident and decided to add them back in with this PR. Thanks for this cool demo! :)